### PR TITLE
Fix zero-drift ∂, generalize feynman_kac, harden tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure || false }}
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 2.5.2
+
+### Fixed
+- `∂(::DiffusionProcess)` no longer produces `NaN` rows at nodes where the drift
+  is exactly zero. The operator is now built directly (rather than as
+  `Diagonal(μx) \ generator(…)`, which divided by zero there): it uses an upwind
+  scheme matching `generator`, and falls back to a central difference at interior
+  zero-drift nodes.
+- CI: the nightly Julia job is now correctly allowed to fail
+  (`continue-on-error`) instead of failing the whole workflow. Previously the
+  `allow_failure` matrix key was defined but never referenced.
+
+### Changed
+- `feynman_kac` allocates its output using the promoted element type of its
+  inputs, so `Float32` (and other) element types are preserved instead of being
+  forced to `Float64`.
+- `DiffusionProcess` and `AdditiveFunctionalDiffusion` are now immutable
+  `struct`s, so the invariants checked in their constructors cannot be bypassed.
+- The test suite is organized into `@testset`s and tightened: several
+  expressions that looked like assertions but tested nothing are now real
+  `@test`s, and the zero-drift `∂` path and `feynman_kac` element type are
+  covered.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 2.5.2
+## 2.6.0
+
+### Breaking
+- `DiffusionProcess` and `AdditiveFunctionalDiffusion` are now immutable
+  `struct`s (previously `mutable struct`), so the invariants checked in their
+  constructors cannot be bypassed. Code that reassigned their fields after
+  construction will no longer work.
 
 ### Fixed
 - `∂(::DiffusionProcess)` no longer produces `NaN` rows at nodes where the drift
@@ -16,8 +22,6 @@
 - `feynman_kac` allocates its output using the promoted element type of its
   inputs, so `Float32` (and other) element types are preserved instead of being
   forced to `Float64`.
-- `DiffusionProcess` and `AdditiveFunctionalDiffusion` are now immutable
-  `struct`s, so the invariants checked in their constructors cannot be bypassed.
 - The test suite is organized into `@testset`s and tightened: several
   expressions that looked like assertions but tested nothing are now real
   `@test`s, and the zero-drift `∂` path and `feynman_kac` element type are

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InfinitesimalGenerators"
 uuid = "2fce0c6f-5f0b-5c85-85c9-2ffe1d5ee30d"
 authors = ["Matthieu Gomez <gomez.matthieu@gmail.com>"]
-version = "2.5.2"
+version = "2.6.0"
 
 [deps]
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,7 @@
 name = "InfinitesimalGenerators"
 uuid = "2fce0c6f-5f0b-5c85-85c9-2ffe1d5ee30d"
-version = "2.5.1"
+authors = ["Matthieu Gomez <gomez.matthieu@gmail.com>"]
+version = "2.5.2"
 
 [deps]
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 [![Build status](https://github.com/matthieugomez/InfinitesimalGenerators.jl/workflows/CI/badge.svg)](https://github.com/matthieugomez/InfinitesimalGenerators.jl/actions)
+[![Coverage](https://codecov.io/gh/matthieugomez/InfinitesimalGenerators.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/matthieugomez/InfinitesimalGenerators.jl)
 
 This package provides a set of tools to work with Markov Processes defined on a 1-dimensional grid.
+
+# Installation
+```julia
+using Pkg
+Pkg.add("InfinitesimalGenerators")
+```
 
 # Markov Processes
 The package allows you to compute expectations involving Markov processes.
@@ -27,7 +34,14 @@ MX = generator(X)
 
 # Use the generator to compute E[∫_0^T e^{-∫_0^t v(x_s)ds}f(x_t)dt + e^{-∫_0^T v(x_s)ds}ψ(x_T) | x_0 = x]
 feynman_kac(MX, range(0, 100, step = 1/12); f = zeros(length(x)), ψ = ones(length(x)), v = zeros(length(x)))
+
+# Return the grid the process is defined on
+state_space(X)
 ```
+
+The convenience constructors `OrnsteinUhlenbeck` and `CoxIngersollRoss` choose the grid automatically. By default it spans the `p` and `1 - p` quantiles of the stationary distribution with `length` points; pass `length`, `xmin`, `xmax`, or `pow` (grid-spacing power) to override. A small `p` is recommended when computing the tail index of an additive functional.
+
+Any subtype of `MarkovProcess` works with `generator`, `stationary_distribution`, and `feynman_kac` as long as it defines `generator(X)` (the transition matrix) and `state_space(X)` (the grid).
 
 # Additive Functionals
 Given a Markov process `X`, an additive functional `m` is defined by `dm = μm(x) dt + σm(x) dZm` with `corr(dZm, dZ) = ρ`.

--- a/src/AdditiveFunctional.jl
+++ b/src/AdditiveFunctional.jl
@@ -53,7 +53,7 @@ corr(dZ^m_t, dZ_t) = ρ
 
 ========================================================================================#
 
-mutable struct AdditiveFunctionalDiffusion{TX <: DiffusionProcess, Tμ <: AbstractVector{<:Number}, Tσ <: AbstractVector{<:Number}, TR <: Number} <: AdditiveFunctional
+struct AdditiveFunctionalDiffusion{TX <: DiffusionProcess, Tμ <: AbstractVector{<:Number}, Tσ <: AbstractVector{<:Number}, TR <: Number} <: AdditiveFunctional
     X::TX
     μm::Tμ
     σm::Tσ

--- a/src/MarkovProcess.jl
+++ b/src/MarkovProcess.jl
@@ -29,7 +29,7 @@ end
         dx_t = μ(x_t) dt + σ(x_t) dZ_t
 
 """
-mutable struct DiffusionProcess{TX <: AbstractVector{<:Real}, Tμ <: AbstractVector{<:Real}, Tσ <: AbstractVector{<:Real}} <: MarkovProcess
+struct DiffusionProcess{TX <: AbstractVector{<:Real}, Tμ <: AbstractVector{<:Real}, Tσ <: AbstractVector{<:Real}} <: MarkovProcess
     x::TX
     μx::Tμ
     σx::Tσ
@@ -99,12 +99,38 @@ end
 
 """
     Returns the discretized version of the operator ∂
-    
+
         δ: f ⭌ ∂f
 
+    The scheme is upwind with respect to the drift (forward where μx ≥ 0,
+    backward where μx < 0), matching the discretization used in `generator`.
+    At interior nodes where the drift is exactly zero — where upwinding has no
+    preferred direction — a central difference is used instead. (Building the
+    matrix directly avoids the `Diagonal(μx) \\ generator(…)` division, which
+    would produce `NaN` rows wherever μx = 0.)
 """
 function ∂(X::DiffusionProcess)
-    Diagonal(X.μx) \ generator(X.x, X.μx, Zeros(length(X.x)))
+    x, μx = X.x, X.μx
+    n = length(x)
+    D = Tridiagonal(zeros(n - 1), zeros(n), zeros(n - 1))
+    @inbounds for i in 1:n
+        Δxp = x[min(i, n - 1) + 1] - x[min(i, n - 1)]
+        Δxm = x[max(i - 1, 1) + 1] - x[max(i - 1, 1)]
+        if (μx[i] == 0) && (1 < i < n)
+            # zero drift: central difference rather than 0/0
+            D[i, i - 1] -= 1 / (Δxm + Δxp)
+            D[i, i + 1] += 1 / (Δxm + Δxp)
+        elseif (μx[i] >= 0) || (i == 1)
+            # forward (upwind)
+            D[i, min(i + 1, n)] += 1 / Δxp
+            D[i, i]             -= 1 / Δxp
+        else
+            # backward (upwind)
+            D[i, i]             += 1 / Δxm
+            D[i, max(i - 1, 1)] -= 1 / Δxm
+        end
+    end
+    return D
 end
 
 

--- a/src/feynman_kac.jl
+++ b/src/feynman_kac.jl
@@ -19,10 +19,10 @@ u(x, t) = E[∫_0^t e^{-∫_0^s v(x_u) du} f(x_s)ds + e^{-∫_0^t v(x_u)du} ψ(x
 
 The PDE is solved using Euler method with implicit time steps
 """
-function feynman_kac(𝕋, ts; 
-    f::Union{AbstractVector, AbstractMatrix} = zeros(size(𝕋, 1)), 
-    ψ::AbstractVector = zeros(size(𝕋, 1)),
-    v::Union{AbstractVector, AbstractMatrix} = zeros(size(𝕋, 1)),
+function feynman_kac(𝕋, ts;
+    f::Union{AbstractVector, AbstractMatrix} = zeros(eltype(𝕋), size(𝕋, 1)),
+    ψ::AbstractVector = zeros(eltype(𝕋), size(𝕋, 1)),
+    v::Union{AbstractVector, AbstractMatrix} = zeros(eltype(𝕋), size(𝕋, 1)),
     direction= :backward)
     size(𝕋, 1) == size(𝕋, 2) || throw(DimensionMismatch("𝕋 must be square matrix"))
     size(𝕋, 1) == size(f, 1) || throw(DimensionMismatch("𝕋 and f should have the same number of rows"))
@@ -44,7 +44,8 @@ function feynman_kac(𝕋, ts;
         return u[:,end:-1:1]
     else
         # direction is backward
-        u = zeros(size(𝕋, 1), length(ts))
+        T = float(promote_type(eltype(𝕋), eltype(f), eltype(ψ), eltype(v), eltype(ts)))
+        u = zeros(T, size(𝕋, 1), length(ts))
         u[:, end] = ψ
         if ndims(f) == 1
             # f and v are vectors

--- a/src/principal_eigenvalue.jl
+++ b/src/principal_eigenvalue.jl
@@ -10,10 +10,13 @@ Two cases:
    The eigenvector is found by solving 𝕋r = 0 with r[1] = 1.
 2. Otherwise, η is found by inverse iteration with Rayleigh quotient updates.
    At each step, we solve (𝕋 - σI)w = r, normalize w, and update the shift σ
-   via the Rayleigh quotient σ = r'𝕋r. This converges cubically to η.
-   The initial shift is the max row sum — a Gershgorin upper bound on η —
-   which guarantees that η is the eigenvalue closest to the shift,
-   so inverse iteration converges to the right eigenvalue.
+   via the Rayleigh quotient σ = r'𝕋r. This converges cubically to a nearby
+   eigenvalue. The initial shift is the max row sum — a Gershgorin upper bound
+   on the real part of the spectrum. When 𝕋 has a real spectrum (e.g. the
+   tridiagonal generators of 1-D diffusions, which are similar to symmetric
+   matrices), the eigenvalue nearest that shift is the principal one, so the
+   iteration lands on η. For a general Metzler matrix with complex eigenvalues
+   this is not guaranteed; pass `η0` to start from a known bound if needed.
    For tridiagonal 𝕋, each iteration costs O(n).
 """
 function principal_eigenvalue(𝕋; r0 = ones(size(𝕋, 1)), η0 = nothing, maxiter = 100, tol = 1e-12)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,180 +1,204 @@
-using InfinitesimalGenerators, Test, Statistics, LinearAlgebra,  Expokit
+using InfinitesimalGenerators, Test, Statistics, LinearAlgebra, Expokit
 
-
+# Shared Ornstein–Uhlenbeck process used across several test sets
 xbar = 0.0
 κ = 0.1
 σ = 0.02
 X = OrnsteinUhlenbeck(; xbar = xbar, κ = κ, σ = σ, length = 1000)
 
 
-## Feynman-Kac
-ψ = X.x.^2
-ts = range(0, stop = 100, step = 1/10)
-u = feynman_kac(generator(X), ts; ψ = ψ, direction = :forward)
-@test maximum(abs, u[:, 50] .- expmv(ts[50], generator(X), ψ)) <= 1e-3
-@test maximum(abs, u[:, 200] .- expmv(ts[200], generator(X), ψ)) <= 1e-3
-@test maximum(abs, u[:, end] .- expmv(ts[end], generator(X), ψ)) <= 1e-5
-@test maximum(abs, feynman_kac(generator(X), ts; ψ = ψ, direction = :forward) .- feynman_kac(generator(X), ts; ψ = ψ, direction = :forward)) <= 1e-5
+@testset "Feynman-Kac" begin
+    ψ = X.x.^2
+    ts = range(0, stop = 100, step = 1/10)
+    u = feynman_kac(generator(X), ts; ψ = ψ, direction = :forward)
+    @test maximum(abs, u[:, 50] .- expmv(ts[50], generator(X), ψ)) <= 1e-3
+    @test maximum(abs, u[:, 200] .- expmv(ts[200], generator(X), ψ)) <= 1e-3
+    @test maximum(abs, u[:, end] .- expmv(ts[end], generator(X), ψ)) <= 1e-5
+    @test maximum(abs, feynman_kac(generator(X), ts; ψ = ψ, direction = :forward) .- feynman_kac(generator(X), ts; ψ = ψ, direction = :forward)) <= 1e-5
 
-T_scalar = zeros(1, 1)
-ts_scalar = 0:1:2
-f_scalar = reshape([1.0, 2.0, 3.0], 1, :)
-v_scalar = reshape([0.0, 1.0, 3.0], 1, :)
-u_scalar = feynman_kac(T_scalar, ts_scalar; f = f_scalar, ψ = [1.0], v = v_scalar, direction = :forward)
-u_expected = zeros(1, length(ts_scalar))
-u_expected[:, 1] .= 1.0
-for i in 1:(length(ts_scalar) - 1)
-    dt = ts_scalar[i + 1] - ts_scalar[i]
-    B = I + Diagonal(v_scalar[:, i + 1]) * dt
-    u_expected[:, i + 1] = B \ (u_expected[:, i] .+ f_scalar[:, i + 1] .* dt)
+    # scalar generator with time-varying f and v
+    T_scalar = zeros(1, 1)
+    ts_scalar = 0:1:2
+    f_scalar = reshape([1.0, 2.0, 3.0], 1, :)
+    v_scalar = reshape([0.0, 1.0, 3.0], 1, :)
+    u_scalar = feynman_kac(T_scalar, ts_scalar; f = f_scalar, ψ = [1.0], v = v_scalar, direction = :forward)
+    u_expected = zeros(1, length(ts_scalar))
+    u_expected[:, 1] .= 1.0
+    for i in 1:(length(ts_scalar) - 1)
+        dt = ts_scalar[i + 1] - ts_scalar[i]
+        B = I + Diagonal(v_scalar[:, i + 1]) * dt
+        u_expected[:, i + 1] = B \ (u_expected[:, i] .+ f_scalar[:, i + 1] .* dt)
+    end
+    @test u_scalar ≈ u_expected
 end
-@test u_scalar ≈ u_expected
-
-g_discounted = stationary_distribution(X; δ = 1e-2)
-@test all(isfinite, g_discounted)
-@test sum(g_discounted) ≈ 1.0 atol = 1e-12
-@test all(g_discounted .>= 0.0)
-@test_throws ArgumentError stationary_distribution(X; δ = 1e-2, ψ = zeros(length(X.x)))
-@test_throws ArgumentError DiffusionProcess([0.0], [0.0], [1.0])
-@test_throws ArgumentError DiffusionProcess([0.0, 0.0, 1.0], zeros(3), ones(3))
-@test_throws ArgumentError DiffusionProcess([0.0, 1.0, 0.5], zeros(3), ones(3))
 
 
-## Multiplicative Functional dM/M = x dt
-m = AdditiveFunctionalDiffusion(X, X.x, zeros(length(X.x)))
-η, r = cgf(m)(1)
-@test η ≈ xbar + 0.5 * σ^2 / κ^2 atol = 1e-2
-r_analytic = exp.(X.x ./ κ) 
-@test norm(r ./ sum(r) .- r_analytic ./ sum(r_analytic)) <= 2 * 1e-3
-ts = range(0, stop = 200, step = 1/10)
-u = feynman_kac(generator(m), ts; direction = :forward, ψ = ones(size(generator(m), 1)))
-@test log.(stationary_distribution(X)' * u[:, end]) ./ ts[end] ≈ η atol = 1e-2
+@testset "feynman_kac element type" begin
+    # output element type should follow the inputs, not be hard-coded to Float64
+    Xf = OrnsteinUhlenbeck(; κ = 0.1, σ = 0.02, length = 50)
+    M = generator(Xf)
+    𝕋 = Tridiagonal(Float32.(M.dl), Float32.(M.d), Float32.(M.du))
+    ts = range(0f0, stop = 10f0, step = 0.1f0)
+    u = feynman_kac(𝕋, ts; ψ = Float32.(Xf.x .^ 2), direction = :forward)
+    @test eltype(u) == Float32
+    @test all(isfinite, u)
+end
 
 
-# test speed
-μm = - 0.06
-m = AdditiveFunctionalDiffusion(X, X.x .+ μm, zeros(length(X.x)))
-ζ = tail_index(m)
-@test μm * ζ + 0.5 * ζ^2 * (σ^2 / κ^2) ≈ 0.0 atol = 1e-2
-η, r = cgf(m ; eigenvector = :right)(ζ)
-η, l = cgf(m ; eigenvector = :left)(ζ)
-f =  exp.(ζ .* X.x ./ κ)
-norm(f ./ sum(f) .- r ./ sum(r)) <= 1e-2
-ψ_reaching = r.* l ./ sum(r .* l)
-speed = sum(ψ_reaching .* m.μm) 
-@test speed ≈ μm  +  ζ * (σ^2 / κ^2) atol = 1e-2
+@testset "stationary_distribution" begin
+    g_discounted = stationary_distribution(X; δ = 1e-2)
+    @test all(isfinite, g_discounted)
+    @test sum(g_discounted) ≈ 1.0 atol = 1e-12
+    @test all(g_discounted .>= 0.0)
+    @test_throws ArgumentError stationary_distribution(X; δ = 1e-2, ψ = zeros(length(X.x)))
+    @test_throws ArgumentError DiffusionProcess([0.0], [0.0], [1.0])
+    @test_throws ArgumentError DiffusionProcess([0.0, 0.0, 1.0], zeros(3), ones(3))
+    @test_throws ArgumentError DiffusionProcess([0.0, 1.0, 0.5], zeros(3), ones(3))
+end
 
 
-# test transformation with a function # m2 = p * M.
-# Note: this works only if the distribution of p has a thinner tail than the distribution of M
-m = AdditiveFunctionalDiffusion(X, X.x .- 0.06, zeros(length(X.x)))
-ζ = tail_index(m)
-η, r = cgf(m ; eigenvector = :right)(ζ)
-η, l = cgf(m ; eigenvector = :left)(ζ)
-p =  exp.(5 .* X.x)
-m2 = AdditiveFunctionalDiffusion(X, m.μm .+ (generator(m.X) * log.(p)),  (InfinitesimalGenerators.∂(X) * log.(p)) .* X.σx, ρ = 1)
-η2, r2 = cgf(m2; eigenvector = :right)(ζ)
-η2, l2 = cgf(m2; eigenvector = :left)(ζ)
-r3 = (r ./ p.^ζ) ./ sum(r ./ p.^ζ)
-r2 = r2 ./ sum(r2)
-#@test r2 ≈ r3 rtol = 1e-2
-l3 = (l .* p.^ζ) ./ sum(l .* p.^ζ)
-#@test l2 ≈ l3 rtol = 1e-1
-
-l' * (generator(m.X) * log.(p))
-ψ_reaching = l.*r ./ sum(l.* r)
-ψ_reaching' * (generator(m.X) * log.(p))
-
-## test left and right eigenvector with correlation
-m = AdditiveFunctionalDiffusion(X, X.x, 0.01 * ones(length(X.x)); ρ = 1)
-η, r = cgf(m; eigenvector = :right)(1)
-η, l = cgf(m; eigenvector = :left)(1)
-
-ψ_tilde = stationary_distribution(DiffusionProcess(X.x, X.μx .+ m.ρ .* m.σm .* X.σx, X.σx))
-@test (r .* ψ_tilde) ./ sum(r .* ψ_tilde) ≈ l rtol = 1e-3
+@testset "Multiplicative functional: cgf" begin
+    # dM/M = x dt
+    m = AdditiveFunctionalDiffusion(X, X.x, zeros(length(X.x)))
+    η, r = cgf(m)(1)
+    @test η ≈ xbar + 0.5 * σ^2 / κ^2 atol = 1e-2
+    r_analytic = exp.(X.x ./ κ)
+    @test norm(r ./ sum(r) .- r_analytic ./ sum(r_analytic)) <= 2 * 1e-3
+    ts = range(0, stop = 200, step = 1/10)
+    u = feynman_kac(generator(m), ts; direction = :forward, ψ = ones(size(generator(m), 1)))
+    @test log.(stationary_distribution(X)' * u[:, end]) ./ ts[end] ≈ η atol = 1e-2
+end
 
 
-# Test Multiplicative with ρ = 0.0
-μm = -0.01
-σm = 0.1
-m = AdditiveFunctionalDiffusion(X, μm .+ X.x, σm .* ones(length(X.x)))
-ζ = tail_index(m)
-ζ_analytic = 2 * (-μm) / (σm^2 + (σ / κ)^2)
-@test ζ ≈ ζ_analytic atol = 1e-2
-η, r = cgf(m; eigenvector = :right)(ζ)
-η, l = cgf(m; eigenvector = :left)(ζ)
-@test η ≈ 0.0 atol = 1e-4
-ψ = stationary_distribution(X)
-@test (r .* ψ) ./ sum(r .* ψ) ≈ l rtol = 1e-3
+@testset "tail_index and speed" begin
+    μm = -0.06
+    m = AdditiveFunctionalDiffusion(X, X.x .+ μm, zeros(length(X.x)))
+    ζ = tail_index(m)
+    @test μm * ζ + 0.5 * ζ^2 * (σ^2 / κ^2) ≈ 0.0 atol = 1e-2
+    η, r = cgf(m; eigenvector = :right)(ζ)
+    η, l = cgf(m; eigenvector = :left)(ζ)
+    f = exp.(ζ .* X.x ./ κ)
+    @test norm(f ./ sum(f) .- r ./ sum(r)) <= 1e-2
+    ψ_reaching = r .* l ./ sum(r .* l)
+    speed = sum(ψ_reaching .* m.μm)
+    @test speed ≈ μm + ζ * (σ^2 / κ^2) atol = 1e-2
+end
 
 
-
-# Test that the modified process μ + σ^2 ∂ ln(r) has a stationary distribution given by $r^2ψ$
-X = OrnsteinUhlenbeck(;κ =κ, σ = σ, length = 1000)
-m = AdditiveFunctionalDiffusion(X, μm .+ X.x .- 0.02, σm .* ones(length(X.x)))
-ψ = stationary_distribution(X)
-ζ = tail_index(m)
-η, r = cgf(m; eigenvector = :right)(ζ)
-η, l = cgf(m; eigenvector = :left)(ζ)
-ψ_cond = stationary_distribution(DiffusionProcess(X.x, X.μx .+ X.σx.^2 .* (InfinitesimalGenerators.∂(X) * log.(r)), X.σx))
-@test (r.^2 .* ψ) ./ sum(r.^2 .* ψ) ≈ ψ_cond rtol = 1e-1
+@testset "left/right eigenvectors (correlated)" begin
+    m = AdditiveFunctionalDiffusion(X, X.x, 0.01 * ones(length(X.x)); ρ = 1)
+    η, r = cgf(m; eigenvector = :right)(1)
+    η, l = cgf(m; eigenvector = :left)(1)
+    ψ_tilde = stationary_distribution(DiffusionProcess(X.x, X.μx .+ m.ρ .* m.σm .* X.σx, X.σx))
+    @test (r .* ψ_tilde) ./ sum(r .* ψ_tilde) ≈ l rtol = 1e-3
+end
 
 
-# Test Multiplicative with ρ = 1.0
-m = AdditiveFunctionalDiffusion(X, m.μm, m.σm; ρ = 1.0)
-ζ = tail_index(m)
-η, r = cgf(m; eigenvector = :right)(ζ)
-η, l = cgf(m; eigenvector = :left)(ζ)
-@test η ≈ 0.0 atol = 1e-3
-ψ_tilde = stationary_distribution(DiffusionProcess(X.x, X.μx .+ ζ .* m.σm .* m.ρ .* X.σx , X.σx))
-@test (r .* ψ_tilde) ./ sum(r .* ψ_tilde) ≈ l rtol = 1e-3
-
-# Test CIR
-gbar = 0.03
-σ = 0.01
-X = CoxIngersollRoss(xbar = gbar, κ = κ, σ = σ)
-m = AdditiveFunctionalDiffusion(X, X.x, zeros(length(X.x)))
-η_analytic = gbar * κ^2 / σ^2 * (1 - sqrt(1 - 2 * σ^2 / κ^2))
-@test cgf(m)(1.0)[1] ≈ η_analytic rtol = 1e-2
-
-# for CIR the speed is given by
-# speed_analytic = - (g .- 0.009) + xbar * κ / sqrt(κ^2 - 2 * σ^2 * ζ)
-# η, r = cgf(m, eigenvector = :right)(ζ)
+@testset "Multiplicative functional (ρ = 0)" begin
+    μm = -0.01
+    σm = 0.1
+    m = AdditiveFunctionalDiffusion(X, μm .+ X.x, σm .* ones(length(X.x)))
+    ζ = tail_index(m)
+    ζ_analytic = 2 * (-μm) / (σm^2 + (σ / κ)^2)
+    @test ζ ≈ ζ_analytic atol = 1e-2
+    η, r = cgf(m; eigenvector = :right)(ζ)
+    η, l = cgf(m; eigenvector = :left)(ζ)
+    @test η ≈ 0.0 atol = 1e-4
+    ψ = stationary_distribution(X)
+    @test (r .* ψ) ./ sum(r .* ψ) ≈ l rtol = 1e-3
+end
 
 
-## FirstDerivative and SecondDerivative
-x = range(0.0, stop = 1.0, length = 1000)
-y = x.^2
-dy = FirstDerivative(x, y; direction = :forward)
-@test length(dy) == length(x)
-@test dy[500] ≈ 2 * x[500] atol = 1e-2
-dy_back = FirstDerivative(x, y; direction = :backward)
-@test dy_back[500] ≈ 2 * x[500] atol = 1e-2
-# boundary conditions: forward derivative at last point returns bc
-@test dy[end] == 0.0
-# backward derivative at first point returns bc
-@test dy_back[1] == 0.0
-
-d2y = SecondDerivative(x, y)
-@test length(d2y) == length(x)
-@test d2y[500] ≈ 2.0 atol = 1e-2
+@testset "Twisted process stationary distribution" begin
+    # the modified process μ + σ² ∂ ln(r) has stationary distribution r²ψ
+    Xl = OrnsteinUhlenbeck(; κ = κ, σ = σ, length = 1000)
+    μm = -0.01
+    σm = 0.1
+    m = AdditiveFunctionalDiffusion(Xl, μm .+ Xl.x .- 0.02, σm .* ones(length(Xl.x)))
+    ψ = stationary_distribution(Xl)
+    ζ = tail_index(m)
+    η, r = cgf(m; eigenvector = :right)(ζ)
+    η, l = cgf(m; eigenvector = :left)(ζ)
+    ψ_cond = stationary_distribution(DiffusionProcess(Xl.x, Xl.μx .+ Xl.σx.^2 .* (InfinitesimalGenerators.∂(Xl) * log.(r)), Xl.σx))
+    @test (r.^2 .* ψ) ./ sum(r.^2 .* ψ) ≈ ψ_cond rtol = 1e-1
+end
 
 
-## jointoperator
-X1 = OrnsteinUhlenbeck(; κ = 0.1, σ = 0.02, length = 50)
-X2 = OrnsteinUhlenbeck(; κ = 0.2, σ = 0.03, length = 50)
-T1 = generator(X1)
-T2 = generator(X2)
-Q = [-0.1 0.1; 0.2 -0.2]
-J = jointoperator([T1, T2], Q)
-@test size(J) == (100, 100)
-# rows should sum to zero (generator property)
-@test maximum(abs.(sum(Matrix(J), dims = 2))) < 1e-10
-# principal eigenvalue of a generator should be zero
-Jdense = Matrix(J)
-η, r = InfinitesimalGenerators.principal_eigenvalue(Jdense)
-@test η ≈ 0.0 atol = 1e-8
-@test all(r .> 0)
-@test_throws DimensionMismatch jointoperator([T1], Q)
-@test_throws DimensionMismatch jointoperator([T1, generator(OrnsteinUhlenbeck(; κ = 0.1, σ = 0.02, length = 60))], Q)
-@test_throws DimensionMismatch jointoperator([T1, T2], [-0.1 0.1 0.0; 0.2 -0.2 0.0])
+@testset "Multiplicative functional (ρ = 1)" begin
+    Xl = OrnsteinUhlenbeck(; κ = κ, σ = σ, length = 1000)
+    μm = -0.01
+    σm = 0.1
+    m0 = AdditiveFunctionalDiffusion(Xl, μm .+ Xl.x .- 0.02, σm .* ones(length(Xl.x)))
+    m = AdditiveFunctionalDiffusion(Xl, m0.μm, m0.σm; ρ = 1.0)
+    ζ = tail_index(m)
+    η, r = cgf(m; eigenvector = :right)(ζ)
+    η, l = cgf(m; eigenvector = :left)(ζ)
+    @test η ≈ 0.0 atol = 1e-3
+    ψ_tilde = stationary_distribution(DiffusionProcess(Xl.x, Xl.μx .+ ζ .* m.σm .* m.ρ .* Xl.σx, Xl.σx))
+    @test (r .* ψ_tilde) ./ sum(r .* ψ_tilde) ≈ l rtol = 1e-3
+end
+
+
+@testset "Cox-Ingersoll-Ross" begin
+    gbar = 0.03
+    σ_cir = 0.01
+    Xc = CoxIngersollRoss(xbar = gbar, κ = κ, σ = σ_cir)
+    m = AdditiveFunctionalDiffusion(Xc, Xc.x, zeros(length(Xc.x)))
+    η_analytic = gbar * κ^2 / σ_cir^2 * (1 - sqrt(1 - 2 * σ_cir^2 / κ^2))
+    @test cgf(m)(1.0)[1] ≈ η_analytic rtol = 1e-2
+end
+
+
+@testset "FirstDerivative and SecondDerivative" begin
+    x = range(0.0, stop = 1.0, length = 1000)
+    y = x.^2
+    dy = FirstDerivative(x, y; direction = :forward)
+    @test length(dy) == length(x)
+    @test dy[500] ≈ 2 * x[500] atol = 1e-2
+    dy_back = FirstDerivative(x, y; direction = :backward)
+    @test dy_back[500] ≈ 2 * x[500] atol = 1e-2
+    # boundary conditions: forward derivative at last point returns bc
+    @test dy[end] == 0.0
+    # backward derivative at first point returns bc
+    @test dy_back[1] == 0.0
+
+    d2y = SecondDerivative(x, y)
+    @test length(d2y) == length(x)
+    @test d2y[500] ≈ 2.0 atol = 1e-2
+end
+
+
+@testset "∂ with zero-drift node" begin
+    # grid placed so that x = 0 (and hence μx = 0) is exactly an interior node
+    x = range(-1.0, 1.0, length = 101)
+    μx = -0.1 .* x
+    σx = 0.02 .* ones(length(x))
+    Xz = DiffusionProcess(x, μx, σx)
+    @test μx[51] == 0                       # zero drift at the middle node
+    D = InfinitesimalGenerators.∂(Xz)
+    @test all(isfinite, D)                  # Diagonal(μx) \ generator would give NaN here
+    df = D * (x .^ 2)
+    @test df[51] ≈ 0.0 atol = 1e-12         # central difference: d(x²)/dx = 0 at x = 0
+    @test df[30] ≈ 2 * x[30] atol = 5e-2    # upwind away from the zero-drift node
+end
+
+
+@testset "jointoperator" begin
+    X1 = OrnsteinUhlenbeck(; κ = 0.1, σ = 0.02, length = 50)
+    X2 = OrnsteinUhlenbeck(; κ = 0.2, σ = 0.03, length = 50)
+    T1 = generator(X1)
+    T2 = generator(X2)
+    Q = [-0.1 0.1; 0.2 -0.2]
+    J = jointoperator([T1, T2], Q)
+    @test size(J) == (100, 100)
+    # rows should sum to zero (generator property)
+    @test maximum(abs.(sum(Matrix(J), dims = 2))) < 1e-10
+    # principal eigenvalue of a generator should be zero
+    Jdense = Matrix(J)
+    η, r = InfinitesimalGenerators.principal_eigenvalue(Jdense)
+    @test η ≈ 0.0 atol = 1e-8
+    @test all(r .> 0)
+    @test_throws DimensionMismatch jointoperator([T1], Q)
+    @test_throws DimensionMismatch jointoperator([T1, generator(OrnsteinUhlenbeck(; κ = 0.1, σ = 0.02, length = 60))], Q)
+    @test_throws DimensionMismatch jointoperator([T1, T2], [-0.1 0.1 0.0; 0.2 -0.2 0.0])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,7 @@ end
     Xf = OrnsteinUhlenbeck(; κ = 0.1, σ = 0.02, length = 50)
     M = generator(Xf)
     𝕋 = Tridiagonal(Float32.(M.dl), Float32.(M.d), Float32.(M.du))
-    ts = range(0f0, stop = 10f0, step = 0.1f0)
+    ts = Float32.(0:0.1:10)   # concrete Float32 grid (a Float32 range has Float64 eltype on Julia 1.6)
     u = feynman_kac(𝕋, ts; ψ = Float32.(Xf.x .^ 2), direction = :forward)
     @test eltype(u) == Float32
     @test all(isfinite, u)


### PR DESCRIPTION
- `∂(::DiffusionProcess)` was implemented as `Diagonal(μx) \ generator(…)`, which is `0/0` wherever the drift is exactly zero (e.g. an Ornstein–Uhlenbeck process at `x = x̄`). It is now built directly with the same upwind scheme as `generator`, falling back to a central difference at interior zero-drift nodes. Results are unchanged where `μx ≠ 0`.
- `feynman_kac` element type. Output is allocated with the promoted element type of the inputs instead of hard-coded `Float64`, so `Float32` (and other) inputs are preserved.
- **Immutable structs.** `DiffusionProcess` and `AdditiveFunctionalDiffusion` are now immutable, so their constructor invariants cannot be bypassed (no field is mutated anywhere in the repo).
