### PR TITLE
Use blackboard A for generator notation

### DIFF
--- a/docs/src/distributions.md
+++ b/docs/src/distributions.md
@@ -10,22 +10,22 @@ using InfinitesimalGenerators, LinearAlgebra
 κ, σ = 0.1, 0.05
 X = OrnsteinUhlenbeck(; xbar = 0.0, κ = κ, σ = σ)
 xs = only(state_space(X))
-𝕋 = generator(X)
+𝔸 = generator(X)
 ```
 
 ## Evolving a distribution by hand
 
-If expectations satisfy the backward equation ``\partial_t u = \mathbb{T} u``, densities satisfy its adjoint, the **Kolmogorov forward (Fokker–Planck) equation**:
+If expectations satisfy the backward equation ``\partial_t u = \mathbb{A} u``, densities satisfy its adjoint, the **Kolmogorov forward (Fokker–Planck) equation**:
 
 ```math
-\partial_t g = \mathbb{T}' g.
+\partial_t g = \mathbb{A}' g.
 ```
 
 The transpose is not incidental: ``E[f(x_t)] = g' f`` for any test function, so whatever operator advances expectations backward, its transpose advances the distribution forward. On the discretized state space, `g` is the vector of probability masses at each grid point, and the forward equation is again a linear ODE solved with implicit Euler steps:
 
 ```@example distributions
-function evolve(𝕋, g0, T; dt = 0.1)
-    B = factorize(I - dt * copy(𝕋'))
+function evolve(𝔸, g0, T; dt = 0.1)
+    B = factorize(I - dt * copy(𝔸'))
     g = copy(g0)
     for _ in 1:round(Int, T / dt)
         g = B \ g
@@ -46,22 +46,22 @@ g0[findmin(abs.(xs .- σ / sqrt(2κ)))[2]] = 1.0
 Δx = step(xs)
 plot(xlabel = "log productivity x", ylabel = "cross-sectional density")
 for T in (1, 5, 20, 100)
-    plot!(xs, evolve(𝕋, g0, T) ./ Δx; label = "t = $T")
+    plot!(xs, evolve(𝔸, g0, T) ./ Δx; label = "t = $T")
 end
 current()
 ```
 
-The discretized process is an honest Markov chain — rows of ``\mathbb{T}`` sum to zero and off-diagonals are non-negative — so the masses stay non-negative and sum to one at every date, with no renormalization needed:
+The discretized process is an honest Markov chain — rows of ``\mathbb{A}`` sum to zero and off-diagonals are non-negative — so the masses stay non-negative and sum to one at every date, with no renormalization needed:
 
 ```@example distributions
-sum(evolve(𝕋, g0, 100))
+sum(evolve(𝔸, g0, 100))
 ```
 
 For the Ornstein–Uhlenbeck process the transition distribution is known in closed form — Gaussian with mean ``e^{-\kappa t} x_0`` and variance ``\frac{\sigma^2}{2\kappa}(1 - e^{-2\kappa t})`` — which checks the discretization at, say, ``t = 5``:
 
 ```@example distributions
 t, x0 = 5.0, xs[findmax(g0)[2]]
-gt = evolve(𝕋, g0, t)
+gt = evolve(𝔸, g0, t)
 mean_t = sum(gt .* xs)
 var_t = sum(gt .* xs .^ 2) - mean_t^2
 (; mean_t, closed_mean = exp(-κ * t) * x0,
@@ -75,15 +75,15 @@ The mean is essentially exact: the upwind scheme discretizes the drift ``\kappa(
 As ``t \to \infty`` the distribution converges to the stationary distribution, the fixed point of the forward equation:
 
 ```math
-\mathbb{T}' g = 0, \qquad \textstyle\sum_i g_i = 1.
+\mathbb{A}' g = 0, \qquad \textstyle\sum_i g_i = 1.
 ```
 
-That is a linear system: `g` is the null vector of the transposed generator, normalized to sum to one. By hand, replace one (redundant) row of ``\mathbb{T}'`` with the normalization:
+That is a linear system: `g` is the null vector of the transposed generator, normalized to sum to one. By hand, replace one (redundant) row of ``\mathbb{A}'`` with the normalization:
 
 ```@example distributions
-A = Matrix(𝕋')
-A[end, :] .= 1.0
-g∞ = A \ [zeros(length(xs) - 1); 1.0]
+B = Matrix(𝔸')
+B[end, :] .= 1.0
+g∞ = B \ [zeros(length(xs) - 1); 1.0]
 nothing # hide
 ```
 
@@ -106,15 +106,15 @@ maximum(abs, g - g∞)
 
 Two variations are worth knowing:
 
-- **Convergence check.** The evolved distribution approaches the stationary one at the speed of mean reversion: `maximum(abs, evolve(𝕋, g0, 100) - g)` is of the order of the autocorrelation ``e^{-\kappa \cdot 100} \approx 5 \times 10^{-5}``, and by ``t = 300`` the two agree to machine precision.
-- **Death and rebirth.** `stationary_distribution(X; δ = δ, ψ = ψ)` computes the stationary distribution when agents die at rate ``\delta`` and are reborn with distribution ``\psi`` — the resolvent ``(\delta I - \mathbb{T}')^{-1} \delta \psi`` — which is the relevant object in perpetual-youth and firm-entry models.
+- **Convergence check.** The evolved distribution approaches the stationary one at the speed of mean reversion: `maximum(abs, evolve(𝔸, g0, 100) - g)` is of the order of the autocorrelation ``e^{-\kappa \cdot 100} \approx 5 \times 10^{-5}``, and by ``t = 300`` the two agree to machine precision.
+- **Death and rebirth.** `stationary_distribution(X; δ = δ, ψ = ψ)` computes the stationary distribution when agents die at rate ``\delta`` and are reborn with distribution ``\psi`` — the resolvent ``(\delta I - \mathbb{A}')^{-1} \delta \psi`` — which is the relevant object in perpetual-youth and firm-entry models.
 
 ```@example distributions
-@assert abs(sum(evolve(𝕋, g0, 100)) - 1) <= 1e-10 # hide
+@assert abs(sum(evolve(𝔸, g0, 100)) - 1) <= 1e-10 # hide
 @assert maximum(abs, g - g∞) <= 1e-10 # hide
 @assert abs(mean_t - exp(-κ * t) * x0) <= 1e-3 # hide
 @assert abs(var_t / (σ^2 / (2κ) * (1 - exp(-2κ * t))) - 1) <= 0.1 # hide
-@assert maximum(abs, evolve(𝕋, g0, 100) - g) <= 1e-5 # hide
-@assert maximum(abs, evolve(𝕋, g0, 300) - g) <= 1e-12 # hide
+@assert maximum(abs, evolve(𝔸, g0, 100) - g) <= 1e-5 # hide
+@assert maximum(abs, evolve(𝔸, g0, 300) - g) <= 1e-12 # hide
 nothing # hide
 ```

--- a/docs/src/expectations.md
+++ b/docs/src/expectations.md
@@ -16,7 +16,7 @@ using InfinitesimalGenerators, LinearAlgebra
 κ, σ, ȳ = 0.1, 0.05, 1.0
 Y = OrnsteinUhlenbeck(; xbar = ȳ, κ = κ, σ = σ)
 ys = only(state_space(Y))
-𝕋 = generator(Y)
+𝔸 = generator(Y)
 ```
 
 ## Forecasts by hand
@@ -24,20 +24,22 @@ ys = only(state_space(Y))
 Fix a horizon ``T`` and consider the forecast ``u(y, t) = E[\psi(y_T) \mid y_t = y]``. It solves the **Kolmogorov backward equation**
 
 ```math
-0 = \partial_t u + \mathbb{T} u, \qquad u(\cdot, T) = \psi,
+0 = \partial_t u + \mathbb{A} u, \qquad u(\cdot, T) = \psi,
 ```
 
-where ``\mathbb{T}`` acts on the state argument. After discretizing the state space, ``\mathbb{T}`` is just the matrix above, so this is a linear ODE in ``\mathbb{R}^n``, solved by marching backward from ``T`` with implicit Euler steps:
+where, on the grid, ``\mathbb{A}`` is the matrix representation of the infinitesimal operator
+``(\mathbb{A}f)(y_i) = \lim_{\Delta t \downarrow 0} \left(E[f(y_{t+\Delta t}) \mid y_t = y_i] - f(y_i)\right) / \Delta t``.
+After discretizing the state space, this is a linear ODE in ``\mathbb{R}^n``, solved by marching backward from ``T`` with implicit Euler steps:
 
 ```math
-u_{t - dt} = (I - dt \, \mathbb{T})^{-1} u_t.
+u_{t - dt} = (I - dt \, \mathbb{A})^{-1} u_t.
 ```
 
 In code — factorize once, then one back-substitution per time step:
 
 ```@example expectations
-function expectation(𝕋, ψ, T; dt = 0.01)
-    B = factorize(I - dt * 𝕋)
+function expectation(𝔸, ψ, T; dt = 0.01)
+    B = factorize(I - dt * 𝔸)
     u = copy(ψ)
     for _ in 1:round(Int, T / dt)
         u = B \ u
@@ -45,7 +47,7 @@ function expectation(𝕋, ψ, T; dt = 0.01)
     return u
 end
 
-u = expectation(𝕋, collect(ys), 10.0)   # ψ(y) = y: the conditional mean E[y_T | y_0]
+u = expectation(𝔸, collect(ys), 10.0)   # ψ(y) = y: the conditional mean E[y_T | y_0]
 nothing # hide
 ```
 
@@ -82,11 +84,11 @@ Now price a claim to the flow ``y_t`` discounted at rate ``r``:
 P(y) = E\left[\int_0^\infty e^{-rt} y_t \, dt \,\Big|\, y_0 = y\right].
 ```
 
-Differentiating with respect to the starting date gives the stationary backward equation ``r P = y + \mathbb{T} P`` — the continuous-time analogue of "price equals dividend plus discounted expected price". Discretized, it is a single linear solve in the resolvent of the generator:
+Differentiating with respect to the starting date gives the stationary backward equation ``r P = y + \mathbb{A} P`` — the continuous-time analogue of "price equals dividend plus discounted expected price". Discretized, it is a single linear solve in the resolvent of the generator:
 
 ```@example expectations
 r = 0.05
-P = (r * I - 𝕋) \ collect(ys)
+P = (r * I - 𝔸) \ collect(ys)
 nothing # hide
 ```
 

--- a/docs/src/hjb.md
+++ b/docs/src/hjb.md
@@ -33,13 +33,13 @@ nothing # hide
 Discretize ``a`` on a grid and stack the value functions into `v` (one column per income state). The discretized HJB is then a system
 
 ```math
-\rho v = u(c(v)) + A(c(v)) \, v,
+\rho v = u(c(v)) + \mathbb{A}(c(v)) \, v,
 ```
 
 nonlinear only through the policy ``c(v)``. The key trick of the scheme is *where the policy is evaluated*: compute ``c_n = c(v_n)`` from the **current guess**, freeze it, and take one backward time step of the equation that is now *linear* in the new value ``v_{n+1}``:
 
 ```math
-\left(\left(\rho + \tfrac{1}{\Delta}\right) I - A(c_n)\right) v_{n+1} = u(c_n) + \tfrac{1}{\Delta} v_n.
+\left(\left(\rho + \tfrac{1}{\Delta}\right) I - \mathbb{A}(c_n)\right) v_{n+1} = u(c_n) + \tfrac{1}{\Delta} v_n.
 ```
 
 Each iteration therefore has three steps, and only the last one is a solve — a *linear* one; no nonlinear solver appears anywhere:
@@ -122,7 +122,7 @@ C - Y
 The scheme above buys linearity by evaluating the policy at the *lagged* guess: the step solves for ``v_{n+1}`` under the policy implied by ``v_n``. The alternative — the **fully implicit** step — evaluates the policy at the *new* guess:
 
 ```math
-\left(\left(\rho + \tfrac{1}{\Delta}\right) I - A(c(v_{n+1}))\right) v_{n+1} = u(c(v_{n+1})) + \tfrac{1}{\Delta} v_n.
+\left(\left(\rho + \tfrac{1}{\Delta}\right) I - \mathbb{A}(c(v_{n+1}))\right) v_{n+1} = u(c(v_{n+1})) + \tfrac{1}{\Delta} v_n.
 ```
 
 The unknown now appears inside the policy, so each time step is a genuine **nonlinear system**, solved with Newton's method. This is what [EconPDEs.jl](https://github.com/matthieugomez/EconPDEs.jl) implements, and it is what you want once the equation is more nonlinear than this tutorial's:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,10 +22,10 @@ Pkg.add("InfinitesimalGenerators")
 Every tool in the package is built on one object. For a Markov process ``x_t``, the infinitesimal generator is the operator
 
 ```math
-(\mathbb{T}f)(x) = \lim_{t \downarrow 0} \frac{E[f(x_t) \mid x_0 = x] - f(x)}{t}.
+(\mathbb{A}f)(x) = \lim_{t \downarrow 0} \frac{E[f(x_t) \mid x_0 = x] - f(x)}{t}.
 ```
 
-On a discretized state space with ``n`` points, ``\mathbb{T}`` becomes an ``n \times n`` matrix with non-negative off-diagonal entries and rows summing to zero — the generator (transition-rate) matrix of a continuous-time Markov chain. The package constructs this matrix for [univariate processes](univariate.md) (`DiffusionProcess`, with convenience constructors `OrnsteinUhlenbeck` and `CoxIngersollRoss`; `ContinuousTimeMarkovChain`) and [multivariate ones](multivariate.md) (`ProductProcess`, `SwitchingProcess`, `MultivariateDiffusionProcess`), and the [operators](operators.md) built on it — `stationary_distribution`, `feynman_kac`, `cgf`, `tail_index` — apply to all of them.
+On a discretized state space with ``n`` points, ``\mathbb{A}`` becomes an ``n \times n`` matrix with non-negative off-diagonal entries and rows summing to zero — the generator (transition-rate) matrix of a continuous-time Markov chain. The package constructs this matrix for [univariate processes](univariate.md) (`DiffusionProcess`, with convenience constructors `OrnsteinUhlenbeck` and `CoxIngersollRoss`; `ContinuousTimeMarkovChain`) and [multivariate ones](multivariate.md) (`ProductProcess`, `SwitchingProcess`, `MultivariateDiffusionProcess`), and the [operators](operators.md) built on it — `stationary_distribution`, `feynman_kac`, `cgf`, `tail_index` — apply to all of them.
 
 All built-in process types subtype `ContinuousTimeMarkovProcess{N}`, where `N` is the number of tensor-product state-space axes. A scalar diffusion or a finite-state chain has `N == 1`; `ProductProcess(X, Z)` has `N == ndims(X) + ndims(Z)`. The state shape is `size(X)`, and arrays are flattened in Julia's column-major order when applying `generator(X)`.
 

--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -14,22 +14,22 @@ nothing # hide
 
 ## The generator itself
 
-`generator(X)` returns the generator (transition-rate) matrix ``\mathbb{T}`` of the discretized process — the operator ``f \mapsto \lim_{t \downarrow 0} E[f(x_t) \mid x_0 = x]/t`` acting on the flattened state space. Rows sum to zero and off-diagonals are non-negative, so the matrix can be used directly for anything the package does not provide: exponentials for transition probabilities, resolvents for present values, transposes for densities.
+`generator(X)` returns the generator (transition-rate) matrix ``\mathbb{A}`` of the discretized process — the operator ``f \mapsto \lim_{t \downarrow 0} E[f(x_t) \mid x_0 = x]/t`` acting on the flattened state space. Rows sum to zero and off-diagonals are non-negative, so the matrix can be used directly for anything the package does not provide: exponentials for transition probabilities, resolvents for present values, transposes for densities.
 
 ```@example operators
-𝕋 = generator(X)
+𝔸 = generator(X)
 ```
 
 ## Stationary distributions
 
-`stationary_distribution(X)` solves the Kolmogorov forward equation ``\mathbb{T}' g = 0`` and returns the probability mass at each grid point, shaped like `size(X)` — see the [distribution dynamics tutorial](distributions.md) for the computation by hand:
+`stationary_distribution(X)` solves the Kolmogorov forward equation ``\mathbb{A}' g = 0`` and returns the probability mass at each grid point, shaped like `size(X)` — see the [distribution dynamics tutorial](distributions.md) for the computation by hand:
 
 ```@example operators
 g = stationary_distribution(X)
 sum(g .* xs)   # ≈ xbar
 ```
 
-The keyword form `stationary_distribution(X; δ = δ, ψ = ψ)` computes the stationary distribution when agents die at rate ``\delta`` and are reborn with distribution ``\psi`` — the resolvent ``(\delta I - \mathbb{T}')^{-1} \delta \psi`` — the relevant object in perpetual-youth and firm-entry models:
+The keyword form `stationary_distribution(X; δ = δ, ψ = ψ)` computes the stationary distribution when agents die at rate ``\delta`` and are reborn with distribution ``\psi`` — the resolvent ``(\delta I - \mathbb{A}')^{-1} \delta \psi`` — the relevant object in perpetual-youth and firm-entry models:
 
 ```@example operators
 ψ = zeros(length(xs)); ψ[1] = 1.0    # everyone reborn at the bottom

--- a/docs/src/tail_index.md
+++ b/docs/src/tail_index.md
@@ -43,14 +43,14 @@ nothing # hide
 For a diffusion, ``E[e^{\xi m_t} f(x_t)]`` obeys the same backward equation as an ordinary expectation, except with a *tilted* generator: multiplying by ``e^{\xi m_t}`` adds the instantaneous CGF of the increment, ``\xi \mu_m(x) + \tfrac{1}{2}\xi^2 \sigma_m(x)^2``, to the diagonal:
 
 ```math
-\mathbb{T}_\xi = \mathbb{T} + \text{Diagonal}\left(\xi \mu_m + \tfrac{1}{2} \xi^2 \sigma_m^2\right).
+\mathbb{A}_\xi = \mathbb{A} + \text{Diagonal}\left(\xi \mu_m + \tfrac{1}{2} \xi^2 \sigma_m^2\right).
 ```
 
-As ``t`` grows, ``E[e^{\xi m_t}] \approx e^{\Lambda(\xi) t}`` where ``\Lambda(\xi)`` is the dominant eigenvalue of ``\mathbb{T}_\xi`` — a Perron–Frobenius eigenvalue, real and simple, because ``\mathbb{T}_\xi`` has non-negative off-diagonals. By hand:
+As ``t`` grows, ``E[e^{\xi m_t}] \approx e^{\Lambda(\xi) t}`` where ``\Lambda(\xi)`` is the dominant eigenvalue of ``\mathbb{A}_\xi`` — a Perron–Frobenius eigenvalue, real and simple, because ``\mathbb{A}_\xi`` has non-negative off-diagonals. By hand:
 
 ```@example tail
-𝕋 = generator(X)
-Λ(ξ) = maximum(real, eigvals(Matrix(𝕋 + Diagonal(ξ .* μm .+ 0.5 .* ξ .^ 2 .* σm .^ 2))))
+𝔸 = generator(X)
+Λ(ξ) = maximum(real, eigvals(Matrix(𝔸 + Diagonal(ξ .* μm .+ 0.5 .* ξ .^ 2 .* σm .^ 2))))
 Λ(1.0)
 ```
 

--- a/src/AdditiveFunctional.jl
+++ b/src/AdditiveFunctional.jl
@@ -1,7 +1,7 @@
 abstract type AdditiveFunctional end
 
-# Should define generator which is a generator matrix T such that
-# Tf = lim_{t→0} E[e^{ξ * m_t} f(x_t)|x_0=x]/t
+# Should define generator which is a generator matrix 𝔸 such that
+# 𝔸f = lim_{t→0} E[e^{ξ * m_t} f(x_t)|x_0=x]/t
 
 
 """

--- a/src/ContinuousTimeMarkovProcesses/DiffusionProcess.jl
+++ b/src/ContinuousTimeMarkovProcesses/DiffusionProcess.jl
@@ -26,7 +26,7 @@ state_space(X::DiffusionProcess) = (X.x,)
 """
     Returns the discretized version of the infinitesimal generator of the Diffusion Process
     
-        𝕋: f ⭌ lim 1/t * E[f(x_t)|x_0=x]
+        𝔸: f ⭌ lim 1/t * E[f(x_t)|x_0=x]
                  = μx * ∂f + 0.5 * σx^2 * ∂^2f
 
     defined on the set of functions f such that 
@@ -37,7 +37,7 @@ state_space(X::DiffusionProcess) = (X.x,)
 
     The transpose of this operator corresponds to
         
-        𝕋': g ⭌ v * g - ∂(μx * g) + 0.5 * ∂^2(σx^2 * g)
+        𝔸': g ⭌ v * g - ∂(μx * g) + 0.5 * ∂^2(σx^2 * g)
 
     defined on the set of functions g such that  
         
@@ -51,7 +51,7 @@ end
 
 function generator(x::AbstractVector, μx::AbstractVector, σx::AbstractVector)
     n = length(x)
-    𝕋 = Tridiagonal(zeros(n-1), zeros(n), zeros(n-1))
+    𝔸 = Tridiagonal(zeros(n-1), zeros(n), zeros(n-1))
     @inbounds for i in 1:n
         Δxp = x[min(i, n-1)+1] - x[min(i, n-1)]
         Δxm = x[max(i-1, 1) + 1] - x[max(i-1, 1)]
@@ -59,23 +59,23 @@ function generator(x::AbstractVector, μx::AbstractVector, σx::AbstractVector)
         # upwinding with reflecting boundaries: outward boundary drift is dropped
         if μx[i] >= 0
             if i < n
-                𝕋[i, i + 1] += μx[i] / Δxp
-                𝕋[i, i] -= μx[i] / Δxp
+                𝔸[i, i + 1] += μx[i] / Δxp
+                𝔸[i, i] -= μx[i] / Δxp
             end
         elseif i > 1
-            𝕋[i, i] += μx[i] / Δxm
-            𝕋[i, i - 1] -= μx[i] / Δxm
+            𝔸[i, i] += μx[i] / Δxm
+            𝔸[i, i - 1] -= μx[i] / Δxm
         end
-        𝕋[i, max(i - 1, 1)] += 0.5 * σx[i]^2 / (Δxm * Δx)
-        𝕋[i, i] -= 0.5 * σx[i]^2 * 2 / (Δxm * Δxp)
-        𝕋[i, min(i + 1, n)] += 0.5 * σx[i]^2 / (Δxp * Δx)
+        𝔸[i, max(i - 1, 1)] += 0.5 * σx[i]^2 / (Δxm * Δx)
+        𝔸[i, i] -= 0.5 * σx[i]^2 * 2 / (Δxm * Δxp)
+        𝔸[i, min(i + 1, n)] += 0.5 * σx[i]^2 / (Δxp * Δx)
     end
     # ensure rows sum to zero with machine precision
-    c = sum(𝕋, dims = 2)
+    c = sum(𝔸, dims = 2)
     for i in 1:n
-        𝕋[i, i] -= c[i]
+        𝔸[i, i] -= c[i]
     end
-    return 𝕋
+    return 𝔸
 end
 
 """

--- a/src/InfinitesimalGenerators.jl
+++ b/src/InfinitesimalGenerators.jl
@@ -19,8 +19,8 @@ one-dimensional processes. `size(X)` is derived from those axes, and `ndims(X)`
 returns the type parameter `N`.
 """
 abstract type ContinuousTimeMarkovProcess{N} end
-# This type should define generator(), which returns a generator matrix 𝕋 such that
-# 𝕋f = lim_{t→0} E[f(x_t)|x_0=x]/t
+# This type should define generator(), which returns a generator matrix 𝔸 such that
+# 𝔸f = lim_{t→0} E[f(x_t)|x_0=x]/t
 
 """
     state_space(X::ContinuousTimeMarkovProcess)

--- a/src/operators/feynman_kac.jl
+++ b/src/operators/feynman_kac.jl
@@ -27,15 +27,15 @@ end
 
 """
     feynman_kac(X::ContinuousTimeMarkovProcess, ts; f = nothing, ψ = nothing, v = nothing, direction = :backward)
-    feynman_kac(𝕋::AbstractMatrix, ts; f, ψ, v, direction = :backward)
+    feynman_kac(𝔸::AbstractMatrix, ts; f, ψ, v, direction = :backward)
 
 Solve the Feynman–Kac PDE associated with a Markov process `X` (or directly with a generator
-matrix `𝕋`) on the time grid `ts`, using implicit Euler time steps.
+matrix `𝔸`) on the time grid `ts`, using implicit Euler time steps.
 
 With `direction = :backward`, returns the solution of
 
     u(x, ts[end]) = ψ(x)
-    0 = uₜ + 𝕋u - v(x, t)u + f(x, t)
+    0 = uₜ + 𝔸u - v(x, t)u + f(x, t)
 
 or, equivalently, in integral form,
 
@@ -44,7 +44,7 @@ or, equivalently, in integral form,
 With `direction = :forward`, returns the solution of
 
     u(x, ts[1]) = ψ(x)
-    uₜ = 𝕋u - v(x, t)u + f(x, t)
+    uₜ = 𝔸u - v(x, t)u + f(x, t)
 
 or, equivalently, in integral form,
 
@@ -52,29 +52,29 @@ or, equivalently, in integral form,
 
 For the process form, `f`, `ψ`, and `v` are arrays shaped like the state space (`size(X)`);
 `f` and `v` may also carry a trailing time dimension of length `length(ts)`. The result has
-one slice per date in `ts`. For the matrix form, they are vectors of length `size(𝕋, 1)`.
+one slice per date in `ts`. For the matrix form, they are vectors of length `size(𝔸, 1)`.
 """
 function feynman_kac(X::ContinuousTimeMarkovProcess, ts; f = nothing, ψ = nothing, v = nothing, direction = :backward)
-    𝕋 = generator(X)
-    f_flat = f === nothing ? zeros(eltype(𝕋), length(X)) :
+    𝔸 = generator(X)
+    f_flat = f === nothing ? zeros(eltype(𝔸), length(X)) :
         _flatten_state_time_argument(X, f, ts, :f)
-    ψ_flat = ψ === nothing ? zeros(eltype(𝕋), length(X)) :
+    ψ_flat = ψ === nothing ? zeros(eltype(𝔸), length(X)) :
         _flatten_state_vector_argument(X, ψ, :ψ)
-    v_flat = v === nothing ? zeros(eltype(𝕋), length(X)) :
+    v_flat = v === nothing ? zeros(eltype(𝔸), length(X)) :
         _flatten_state_time_argument(X, v, ts, :v)
-    u = feynman_kac(𝕋, ts; f = f_flat, ψ = ψ_flat, v = v_flat, direction = direction)
+    u = feynman_kac(𝔸, ts; f = f_flat, ψ = ψ_flat, v = v_flat, direction = direction)
     return _reshape_state_time_output(X, u)
 end
 
-function feynman_kac(𝕋, ts;
-    f::Union{AbstractVector, AbstractMatrix} = zeros(eltype(𝕋), size(𝕋, 1)),
-    ψ::AbstractVector = zeros(eltype(𝕋), size(𝕋, 1)),
-    v::Union{AbstractVector, AbstractMatrix} = zeros(eltype(𝕋), size(𝕋, 1)),
+function feynman_kac(𝔸, ts;
+    f::Union{AbstractVector, AbstractMatrix} = zeros(eltype(𝔸), size(𝔸, 1)),
+    ψ::AbstractVector = zeros(eltype(𝔸), size(𝔸, 1)),
+    v::Union{AbstractVector, AbstractMatrix} = zeros(eltype(𝔸), size(𝔸, 1)),
     direction= :backward)
-    size(𝕋, 1) == size(𝕋, 2) || throw(DimensionMismatch("𝕋 must be square matrix"))
-    size(𝕋, 1) == size(f, 1) || throw(DimensionMismatch("𝕋 and f should have the same number of rows"))
-    size(𝕋, 1) == length(ψ) || throw(DimensionMismatch("𝕋 and ψ should have the same number of rows"))
-    size(𝕋, 1) == size(v, 1) || throw(DimensionMismatch("𝕋 and v should have the same number of rows"))
+    size(𝔸, 1) == size(𝔸, 2) || throw(DimensionMismatch("𝔸 must be square matrix"))
+    size(𝔸, 1) == size(f, 1) || throw(DimensionMismatch("𝔸 and f should have the same number of rows"))
+    size(𝔸, 1) == length(ψ) || throw(DimensionMismatch("𝔸 and ψ should have the same number of rows"))
+    size(𝔸, 1) == size(v, 1) || throw(DimensionMismatch("𝔸 and v should have the same number of rows"))
     size(f, 2) ∈ (1, length(ts)) ||  throw(DimensionMismatch("The number of columns in f should equal the length of ts"))
     size(v, 2) ∈ (1, length(ts)) ||  throw(DimensionMismatch("The number of columns in v should equal the length of ts"))
     direction ∈ (:forward, :backward) || throw(ArgumentError("Direction must be :backward or :forward"))
@@ -87,20 +87,20 @@ function feynman_kac(𝕋, ts;
         # direction is forward
         f_reverse = ndims(f) == 2 ? @view(f[:, end:-1:1]) : f
         v_reverse = ndims(v) == 2 ? @view(v[:, end:-1:1]) : v
-        u = feynman_kac(𝕋, - reverse(ts); ψ = ψ, f = f_reverse, v = v_reverse, direction = :backward)
+        u = feynman_kac(𝔸, - reverse(ts); ψ = ψ, f = f_reverse, v = v_reverse, direction = :backward)
         return u[:,end:-1:1]
     else
         # direction is backward
-        T = float(promote_type(eltype(𝕋), eltype(f), eltype(ψ), eltype(v), eltype(ts)))
-        u = zeros(T, size(𝕋, 1), length(ts))
+        T = float(promote_type(eltype(𝔸), eltype(f), eltype(ψ), eltype(v), eltype(ts)))
+        u = zeros(T, size(𝔸, 1), length(ts))
         u[:, end] = ψ
         if ndims(f) == 1
             # f and v are vectors
             if isa(ts, AbstractRange)
                 # constant time step
                 dt = step(ts)
-                B = factorize(I + (Diagonal(v) - 𝕋) * dt)
-                rhs = Vector{T}(undef, size(𝕋, 1))
+                B = factorize(I + (Diagonal(v) - 𝔸) * dt)
+                rhs = Vector{T}(undef, size(𝔸, 1))
                 # Use in-place solves for tridiagonal/banded factors, but keep
                 # a fallback for sparse factors such as CHOLMOD without ldiv!.
                 can_ldiv = hasmethod(ldiv!, Tuple{typeof(B), typeof(rhs)})
@@ -118,7 +118,7 @@ function feynman_kac(𝕋, ts;
                 # non-constant time step
                 for i in (length(ts)-1):(-1):1
                     dt = ts[i+1] - ts[i]
-                    B = I + (Diagonal(v) - 𝕋) * dt
+                    B = I + (Diagonal(v) - 𝔸) * dt
                     u[:, i] = B \ (u[:, i+1] .+ f .* dt)
                 end
             end
@@ -126,7 +126,7 @@ function feynman_kac(𝕋, ts;
             # f and v are matrices
             for i in (length(ts)-1):(-1):1
                 dt = ts[i+1] - ts[i]
-                B = I + (Diagonal(view(v, :, i)) - 𝕋) * dt
+                B = I + (Diagonal(view(v, :, i)) - 𝔸) * dt
                 u[:, i] = B \ (u[:, i+1] .+ f[:, i] .* dt)
             end
         end

--- a/src/operators/principal_eigenvalue.jl
+++ b/src/operators/principal_eigenvalue.jl
@@ -1,31 +1,31 @@
 """
-Compute the principal eigenvalue and eigenvector of a Metzler matrix 𝕋
+Compute the principal eigenvalue and eigenvector of a Metzler matrix 𝔸
 (i.e. a matrix with non-negative off-diagonal entries).
 
 By Perron-Frobenius, the eigenvalue η with largest real part is real,
 and the corresponding eigenvector r is strictly positive.
 
 Two cases:
-1. If rows or columns sum to zero (𝕋 is a generator), then η = 0.
-   The eigenvector is found by solving 𝕋r = 0 with r[1] = 1.
+1. If rows or columns sum to zero (𝔸 is a generator), then η = 0.
+   The eigenvector is found by solving 𝔸r = 0 with r[1] = 1.
 2. Otherwise, η is found by inverse iteration with Rayleigh quotient updates.
-   At each step, we solve (𝕋 - σI)w = r, normalize w, and update the shift σ
-   via the Rayleigh quotient σ = r'𝕋r. This converges cubically to a nearby
+   At each step, we solve (𝔸 - σI)w = r, normalize w, and update the shift σ
+   via the Rayleigh quotient σ = r'𝔸r. This converges cubically to a nearby
    eigenvalue. The initial shift is the max row sum — a Gershgorin upper bound
-   on the real part of the spectrum. When 𝕋 has a real spectrum (e.g. the
+   on the real part of the spectrum. When 𝔸 has a real spectrum (e.g. the
    tridiagonal generators of 1-D diffusions, which are similar to symmetric
    matrices), the eigenvalue nearest that shift is the principal one, so the
    iteration lands on η. For a general Metzler matrix with complex eigenvalues
    this is not guaranteed; pass `η0` to start from a known bound if needed.
-   For tridiagonal 𝕋, each iteration costs O(n).
+   For tridiagonal 𝔸, each iteration costs O(n).
 """
-function principal_eigenvalue(𝕋; r0 = ones(size(𝕋, 1)), η0 = nothing, maxiter = 100, tol = 1e-12)
-    if (maximum(abs.(sum(𝕋, dims = 1))) < 1e-9) || (maximum(abs.(sum(𝕋, dims = 2))) < 1e-9)
-        # rows or columns sum to zero → η = 0, solve 𝕋r = 0 with r[1] = 1
-        if 𝕋 isa Tridiagonal
-            r = [1.0 ; - Tridiagonal(𝕋.dl[2:end], 𝕋.d[2:end], 𝕋.du[2:end]) \ vec(𝕋[2:end, 1])]
+function principal_eigenvalue(𝔸; r0 = ones(size(𝔸, 1)), η0 = nothing, maxiter = 100, tol = 1e-12)
+    if (maximum(abs.(sum(𝔸, dims = 1))) < 1e-9) || (maximum(abs.(sum(𝔸, dims = 2))) < 1e-9)
+        # rows or columns sum to zero → η = 0, solve 𝔸r = 0 with r[1] = 1
+        if 𝔸 isa Tridiagonal
+            r = [1.0 ; - Tridiagonal(𝔸.dl[2:end], 𝔸.d[2:end], 𝔸.du[2:end]) \ vec(𝔸[2:end, 1])]
         else
-            r = [1.0 ; - 𝕋[2:end, 2:end] \ collect(𝕋[2:end, 1])]
+            r = [1.0 ; - 𝔸[2:end, 2:end] \ collect(𝔸[2:end, 1])]
         end
         return 0.0, abs.(r)
     else
@@ -35,12 +35,12 @@ function principal_eigenvalue(𝕋; r0 = ones(size(𝕋, 1)), η0 = nothing, max
         if η0 !== nothing
             η = float(η0)
         else
-            η = maximum(sum(𝕋, dims = 2))
+            η = maximum(sum(𝔸, dims = 2))
         end
         for _ in 1:maxiter
-            w = (𝕋 - η * I) \ r
+            w = (𝔸 - η * I) \ r
             r = w ./ sqrt(w' * w)
-            η_new = r' * (𝕋 * r)
+            η_new = r' * (𝔸 * r)
             if abs(η_new - η) < tol * (1 + abs(η_new))
                 return η_new, abs.(r)
             end

--- a/src/operators/stationary_distribution.jl
+++ b/src/operators/stationary_distribution.jl
@@ -1,18 +1,18 @@
 """
-    stationary_distribution(𝕋; δ = 0.0, ψ = Ones(size(𝕋, 1)))
+    stationary_distribution(𝔸; δ = 0.0, ψ = Ones(size(𝔸, 1)))
 
-Computes the stationary distribution corresponding to the generator matrix `𝕋`.
+Computes the stationary distribution corresponding to the generator matrix `𝔸`.
 """
-function stationary_distribution(𝕋::AbstractMatrix; δ = 0.0, ψ = Ones(size(𝕋, 1)))
-    size(𝕋, 1) == size(𝕋, 2) || throw(DimensionMismatch("𝕋 must be a square generator matrix"))
+function stationary_distribution(𝔸::AbstractMatrix; δ = 0.0, ψ = Ones(size(𝔸, 1)))
+    size(𝔸, 1) == size(𝔸, 2) || throw(DimensionMismatch("𝔸 must be a square generator matrix"))
     δ >= 0 || throw(ArgumentError("δ needs to be nonnegative"))
-    n = size(𝕋, 1)
+    n = size(𝔸, 1)
     ψ = vec(ψ)
-    length(ψ) == n || throw(DimensionMismatch("𝕋 and ψ should have the same length"))
+    length(ψ) == n || throw(DimensionMismatch("𝔸 and ψ should have the same length"))
     if δ > 0
-        g = abs.((δ * I - 𝕋') \ (δ * collect(ψ)))
+        g = abs.((δ * I - 𝔸') \ (δ * collect(ψ)))
     else
-        η, g = principal_eigenvalue(𝕋')
+        η, g = principal_eigenvalue(𝔸')
         abs(η) <= 1e-5 || @warn "Principal Eigenvalue does not seem to be zero"
     end
     total_mass = sum(g)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,16 +23,16 @@ InfinitesimalGenerators.generator(::CustomMarkovProcess) = [-1.0 1.0; 2.0 -2.0]
     @test maximum(abs, u[:, end] .- expmv(ts[end], generator(X), ψ)) <= 1e-5
     @test maximum(abs, feynman_kac(generator(X), ts; ψ = ψ, direction = :forward) .- feynman_kac(generator(X), ts; ψ = ψ, direction = :forward)) <= 1e-5
 
-    T_sparse = sparse([-1.0 1.0; 1.0 -1.0])
-    u_sparse = feynman_kac(T_sparse, 0.0:1.0:2.0; f = zeros(2), ψ = ones(2))
+    𝔸_sparse = sparse([-1.0 1.0; 1.0 -1.0])
+    u_sparse = feynman_kac(𝔸_sparse, 0.0:1.0:2.0; f = zeros(2), ψ = ones(2))
     @test u_sparse ≈ ones(2, 3)
 
     # scalar generator with time-varying f and v
-    T_scalar = zeros(1, 1)
+    𝔸_scalar = zeros(1, 1)
     ts_scalar = 0:1:2
     f_scalar = reshape([1.0, 2.0, 3.0], 1, :)
     v_scalar = reshape([0.0, 1.0, 3.0], 1, :)
-    u_scalar = feynman_kac(T_scalar, ts_scalar; f = f_scalar, ψ = [1.0], v = v_scalar, direction = :forward)
+    u_scalar = feynman_kac(𝔸_scalar, ts_scalar; f = f_scalar, ψ = [1.0], v = v_scalar, direction = :forward)
     u_expected = zeros(1, length(ts_scalar))
     u_expected[:, 1] .= 1.0
     for i in 1:(length(ts_scalar) - 1)
@@ -42,20 +42,20 @@ InfinitesimalGenerators.generator(::CustomMarkovProcess) = [-1.0 1.0; 2.0 -2.0]
     end
     @test u_scalar ≈ u_expected
 
-    u_matrix_f = feynman_kac(T_scalar, ts_scalar; f = f_scalar, ψ = [0.0], v = [0.0])
-    @test u_matrix_f ≈ feynman_kac(T_scalar, ts_scalar; f = f_scalar, ψ = [0.0], v = zeros(1, length(ts_scalar)))
-    u_matrix_v = feynman_kac(T_scalar, ts_scalar; f = [1.0], ψ = [0.0], v = v_scalar)
-    @test u_matrix_v ≈ feynman_kac(T_scalar, ts_scalar; f = ones(1, length(ts_scalar)), ψ = [0.0], v = v_scalar)
+    u_matrix_f = feynman_kac(𝔸_scalar, ts_scalar; f = f_scalar, ψ = [0.0], v = [0.0])
+    @test u_matrix_f ≈ feynman_kac(𝔸_scalar, ts_scalar; f = f_scalar, ψ = [0.0], v = zeros(1, length(ts_scalar)))
+    u_matrix_v = feynman_kac(𝔸_scalar, ts_scalar; f = [1.0], ψ = [0.0], v = v_scalar)
+    @test u_matrix_v ≈ feynman_kac(𝔸_scalar, ts_scalar; f = ones(1, length(ts_scalar)), ψ = [0.0], v = v_scalar)
 end
 
 
 @testset "feynman_kac element type" begin
     # output element type should follow the inputs, not be hard-coded to Float64
     Xf = OrnsteinUhlenbeck(; κ = 0.1, σ = 0.02, length = 50)
-    M = generator(Xf)
-    𝕋 = Tridiagonal(Float32.(M.dl), Float32.(M.d), Float32.(M.du))
+    𝔸64 = generator(Xf)
+    𝔸 = Tridiagonal(Float32.(𝔸64.dl), Float32.(𝔸64.d), Float32.(𝔸64.du))
     ts = Float32.(0:0.1:10)   # concrete Float32 grid (a Float32 range has Float64 eltype on Julia 1.6)
-    u = feynman_kac(𝕋, ts; ψ = Float32.(Xf.x .^ 2), direction = :forward)
+    u = feynman_kac(𝔸, ts; ψ = Float32.(Xf.x .^ 2), direction = :forward)
     @test eltype(u) == Float32
     @test all(isfinite, u)
 end
@@ -419,10 +419,10 @@ end
 @testset "jointoperator" begin
     X1 = OrnsteinUhlenbeck(; κ = 0.1, σ = 0.02, length = 50)
     X2 = OrnsteinUhlenbeck(; κ = 0.2, σ = 0.03, length = 50)
-    T1 = generator(X1)
-    T2 = generator(X2)
+    𝔸1 = generator(X1)
+    𝔸2 = generator(X2)
     Q = [-0.1 0.1; 0.2 -0.2]
-    J = jointoperator([T1, T2], Q)
+    J = jointoperator([𝔸1, 𝔸2], Q)
     @test size(J) == (100, 100)
     # rows should sum to zero (generator property)
     @test maximum(abs.(sum(Matrix(J), dims = 2))) < 1e-10
@@ -435,7 +435,7 @@ end
     η_stalled, r_stalled = @test_logs (:warn, r"Inverse iteration") InfinitesimalGenerators.principal_eigenvalue(A; η0 = 1.23, maxiter = 0)
     @test η_stalled == 1.23
     @test norm(r_stalled) ≈ 1.0
-    @test_throws DimensionMismatch jointoperator([T1], Q)
-    @test_throws DimensionMismatch jointoperator([T1, generator(OrnsteinUhlenbeck(; κ = 0.1, σ = 0.02, length = 60))], Q)
-    @test_throws DimensionMismatch jointoperator([T1, T2], [-0.1 0.1 0.0; 0.2 -0.2 0.0])
+    @test_throws DimensionMismatch jointoperator([𝔸1], Q)
+    @test_throws DimensionMismatch jointoperator([𝔸1, generator(OrnsteinUhlenbeck(; κ = 0.1, σ = 0.02, length = 60))], Q)
+    @test_throws DimensionMismatch jointoperator([𝔸1, 𝔸2], [-0.1 0.1 0.0; 0.2 -0.2 0.0])
 end


### PR DESCRIPTION
Switch generator notation in docs and code examples from T/𝕋 to \mathbb{A}/𝔸, including the expectations tutorial's infinitesimal-limit definition. Verified with package tests and a docs build.